### PR TITLE
make map_signif_level more flexible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,5 @@ Imports:
 Suggests: testthat,
     knitr,
     rmarkdown
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -89,7 +89,7 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
                                 if(p_value < .Machine$double.eps){
                                   sprintf("p < %.2e", .Machine$double.eps)
                                 }else{
-                                  as.character(sprintf("p = %.2g", p_value))
+                                  as.character(sprintf("%.2g", p_value))
                                 }
                               }else{
                                 as.character(p_value)
@@ -174,6 +174,11 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
 #'  geom_boxplot() +
 #'  geom_signif(comparisons = list(c("compact", "pickup"),
 #'                                 c("subcompact", "suv")))
+#' ggplot(mpg, aes(class, hwy)) +
+#'  geom_boxplot() +
+#'  geom_signif(comparisons = list(c("compact", "pickup"),
+#'                                 c("subcompact", "suv")),
+#'              map_signif_level=function(p)sprintf("p = %.2g", p))
 #'
 #' ggplot(mpg, aes(class, hwy)) +
 #'   geom_boxplot() +

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -29,7 +29,7 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
                       stop(paste0("annotations contains a different number of elements (", length(params$annotations),
                                   ") than comparisons or xmin (", max(length(params$comparisons),length(params$xmin), 1), ")."))
 
-                    if(all(params$map_signif_level == TRUE)){
+                    if(all(is.logical(params$map_signif_level)) && all(params$map_signif_level == TRUE)){
                       params$map_signif_level <- c("***"=0.001, "**"=0.01, "*"=0.05)
                     }else if(is.numeric(params$map_signif_level)){
                       if(is.null(names(params$map_signif_level)) ){
@@ -82,12 +82,14 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
                               }else{
                                 temp_value
                               }
+                            }else if(is.function(map_signif_level)){
+                              map_signif_level(p_value)
                             }else{
                               if(is.numeric(p_value)){
                                 if(p_value < .Machine$double.eps){
                                   sprintf("p < %.2e", .Machine$double.eps)
                                 }else{
-                                  as.character(sprrintf("p = %.2g"), p_value)
+                                  as.character(sprintf("p = %.2g"), p_value)
                                 }
                               }else{
                                 as.character(p_value)

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -89,7 +89,7 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
                                 if(p_value < .Machine$double.eps){
                                   sprintf("p < %.2e", .Machine$double.eps)
                                 }else{
-                                  as.character(sprintf("p = %.2g"), p_value)
+                                  as.character(sprintf("p = %.2g", p_value))
                                 }
                               }else{
                                 as.character(p_value)

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -215,7 +215,7 @@ GeomSignif <- ggplot2::ggproto("GeomSignif", ggplot2::Geom,
                            required_aes = c("x", "xend", "y", "yend", "annotation"),
                            default_aes = ggplot2::aes(shape = 19, colour = "black", textsize = 3.88, angle = 0, hjust = 0.5,
                                              vjust = 0, alpha = NA, family = "", fontface = 1, lineheight = 1.2, linetype=1, size=0.5),
-                           draw_key = ggplot2::draw_key_point,
+                           draw_key = function(...){grid::nullGrob()},
 
                            draw_group = function(data, panel_params, coord) {
                              coords <- coord$transform(data, panel_params)

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -145,6 +145,7 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
 #' @param map_signif_level boolean value, if the p-value are directly written as annotation or asterisks are used instead.
 #'   Alternatively one can provide a named numeric vector to create custom mappings from p-values to annotation:
 #'   For example: c("***"=0.001, "**"=0.01, "*"=0.05)
+#'   Alternatively, one can provide a function that takes a numeric argument (the p-value) and returns a string
 #' @param xmin numeric vector with the positions of the left sides of the brackets
 #' @param xmax numeric vector with the positions of the right sides of the brackets
 #' @param y_position numeric vector with the y positions of the brackets

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -84,10 +84,10 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
                               }
                             }else{
                               if(is.numeric(p_value)){
-                                if(p_value < 2.2e-16){
-                                  "< 2.2e-16"
+                                if(p_value < .Machine$double.eps){
+                                  sprintf("p < %.2e", .Machine$double.eps)
                                 }else{
-                                  as.character(signif(p_value, digits=2))
+                                  as.character(sprrintf("p = %.2g"), p_value)
                                 }
                               }else{
                                 as.character(p_value)

--- a/man/stat_signif.Rd
+++ b/man/stat_signif.Rd
@@ -18,28 +18,28 @@ geom_signif(mapping = NULL, data = NULL, stat = "signif",
   inherit.aes = TRUE, comparisons = NULL, test = "wilcox.test",
   test.args = NULL, annotations = NULL, map_signif_level = FALSE,
   y_position = NULL, xmin = NULL, xmax = NULL, margin_top = 0.05,
-  step_increase = 0, tip_length = 0.03, size = 0.5, textsize = 3.88,
-  family = "", vjust = 0, manual = FALSE, ...)
+  step_increase = 0, tip_length = 0.03, size = 0.5,
+  textsize = 3.88, family = "", vjust = 0, manual = FALSE, ...)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
-\code{\link{aes_}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
+\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
-   options:
+options:
 
-   If \code{NULL}, the default, the data is inherited from the plot
-   data as specified in the call to \code{\link{ggplot}}.
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
 
-   A \code{data.frame}, or other object, will override the plot
-   data. All objects will be fortified to produce a data frame. See
-   \code{\link{fortify}} for which variables will be created.
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[=fortify]{fortify()}} for which variables will be created.
 
-   A \code{function} will be called with a single argument,
-   the plot data. The return value must be a \code{data.frame.}, and
-   will be used as the layer data.}
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame}, and
+will be used as the layer data.}
 
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
@@ -49,12 +49,14 @@ a warning.  If \code{TRUE} silently removes missing values.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
-\code{FALSE} never includes, and \code{TRUE} always includes.}
+\code{FALSE} never includes, and \code{TRUE} always includes.
+It can also be a named logical vector to finely select the aesthetics to
+display.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link{borders}}.}
+the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{comparisons}{A list of length-2 vectors.
 The entries in the vector are either the names of 2 values on the x-axis
@@ -69,7 +71,8 @@ If you implement a custom test make sure that it returns a list that has an entr
 
 \item{map_signif_level}{boolean value, if the p-value are directly written as annotation or asterisks are used instead.
 Alternatively one can provide a named numeric vector to create custom mappings from p-values to annotation:
-For example: c("***"=0.001, "**"=0.01, "*"=0.05)}
+For example: c("***"=0.001, "**"=0.01, "*"=0.05)
+Alternatively, one can provide a function that takes a numeric argument (the p-value) and returns a string}
 
 \item{y_position}{numeric vector with the y positions of the brackets}
 


### PR DESCRIPTION
map_signif_level can now take a user-supplied function to format the p-value. Also, this pull-request changes the default threshold for printing exact p-values to .Machine$double.eps (should still be 2e-16 on most computers)