### PR TITLE
New "extend_line" parameter.

### DIFF
--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -164,6 +164,9 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
 #'   displayed as described in `?plotmath`.
 #' @param manual boolean flag that indicates that the parameters are provided with a data.frame. This option is necessary if
 #'   one wants to plot different annotations per facet.
+#' @param extend_line Numeric that allows to shorten (negative values) or extend
+#'   (positive value) the horizontal line between groups for each comparison;
+#'   defaults to 0.
 #' @param na.rm If \code{FALSE} (the default), removes missing values with
 #'    a warning.  If \code{TRUE} silently removes missing values.
 #' @param ... other arguments passed on to \code{\link{layer}}. These are
@@ -233,16 +236,16 @@ GeomSignif <- ggplot2::ggproto("GeomSignif", ggplot2::Geom,
                                lab <- parse_safe(as.character(lab))
                              }
                              coords <- coord$transform(data, panel_params)
-                             if ( extend_line != 0 ) {
-                               # first vertical segment
-                               coords[1,1] <- coords[1,1] - extend_line
-                               coords[1,2] <- coords[1,2] - extend_line
+                             if ( extend_line != 0 & nrow(coords) == 3 ) {
+                               # left vertical segment
+                               coords[1,'x'] <- coords[1,'x'] - extend_line
+                               coords[1,'xend'] <- coords[1,'xend'] - extend_line
                                # horizontal line
-                               coords[2,1] <- coords[2,1] - extend_line
-                               coords[2,2] <- coords[2,2] + extend_line
-                               # second vertical segment
-                               coords[3,1] <- coords[3,1] + extend_line
-                               coords[3,2] <- coords[3,2] + extend_line
+                               coords[2,'x'] <- coords[2,'x'] - extend_line
+                               coords[2,'xend'] <- coords[2,'xend'] + extend_line
+                               # right vertical segment
+                               coords[3,'x'] <- coords[3,'x'] + extend_line
+                               coords[3,'xend'] <- coords[3,'xend'] + extend_line
                              }
                              grid::gList(
                                grid::textGrob(

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -227,12 +227,23 @@ GeomSignif <- ggplot2::ggproto("GeomSignif", ggplot2::Geom,
                                              vjust = 0, alpha = NA, family = "", fontface = 1, lineheight = 1.2, linetype=1, size=0.5),
                            draw_key = function(...){grid::nullGrob()},
 
-                           draw_group = function(data, panel_params, coord, parse=FALSE) {
+                           draw_group = function(data, panel_params, coord, parse=FALSE, extend_line = extend_line) {
                              lab <- as.character(data$annotation)
                              if (parse) {
                                lab <- parse_safe(as.character(lab))
                              }
                              coords <- coord$transform(data, panel_params)
+                             if ( extend_line != 0 ) {
+                               # first vertical segment
+                               coords[1,1] <- coords[1,1] - extend_line
+                               coords[1,2] <- coords[1,2] - extend_line
+                               # horizontal line
+                               coords[2,1] <- coords[2,1] - extend_line
+                               coords[2,2] <- coords[2,2] + extend_line
+                               # second vertical segment
+                               coords[3,1] <- coords[3,1] + extend_line
+                               coords[3,2] <- coords[3,2] + extend_line
+                             }
                              grid::gList(
                                grid::textGrob(
                                  label=lab,
@@ -273,6 +284,7 @@ geom_signif <- function(mapping = NULL, data = NULL, stat = "signif",
                         size=0.5, textsize = 3.88, family="", vjust = 0,
                         parse = FALSE,
                         manual=FALSE,
+                        extend_line = 0,
                         ...) {
   params <- list(na.rm = na.rm, ...)
   if (identical(stat, "signif")) {
@@ -303,7 +315,8 @@ geom_signif <- function(mapping = NULL, data = NULL, stat = "signif",
                    y_position=y_position,xmin=xmin, xmax=xmax,
                    margin_top=margin_top, step_increase=step_increase,
                    tip_length=tip_length, size=size, textsize=textsize,
-                   family=family, vjust=vjust, parse=parse, manual=manual))
+                   family=family, vjust=vjust, parse=parse, manual=manual,
+                   extend_line = extend_line))
   }
   ggplot2::layer(
     stat = stat, geom = GeomSignif, mapping = mapping,  data = data,

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -236,16 +236,29 @@ GeomSignif <- ggplot2::ggproto("GeomSignif", ggplot2::Geom,
                                lab <- parse_safe(as.character(lab))
                              }
                              coords <- coord$transform(data, panel_params)
+                             message(str(coords))
                              if ( extend_line != 0 & nrow(coords) == 3 ) {
-                               # left vertical segment
-                               coords[1,'x'] <- coords[1,'x'] - extend_line
-                               coords[1,'xend'] <- coords[1,'xend'] - extend_line
-                               # horizontal line
-                               coords[2,'x'] <- coords[2,'x'] - extend_line
-                               coords[2,'xend'] <- coords[2,'xend'] + extend_line
-                               # right vertical segment
-                               coords[3,'x'] <- coords[3,'x'] + extend_line
-                               coords[3,'xend'] <- coords[3,'xend'] + extend_line
+                               if ( coords[2,'x'] < coords[2,'xend'] ) {
+                                # left vertical segment
+                                coords[1,'x'] <- coords[1,'x'] - extend_line
+                                coords[1,'xend'] <- coords[1,'xend'] - extend_line
+                                # horizontal line
+                                coords[2,'x'] <- coords[2,'x'] - extend_line
+                                coords[2,'xend'] <- coords[2,'xend'] + extend_line
+                                # right vertical segment
+                                coords[3,'x'] <- coords[3,'x'] + extend_line
+                                coords[3,'xend'] <- coords[3,'xend'] + extend_line
+                               } else if ( coords[2,'x'] > coords[2,'xend'] ) {
+                                # left vertical segment
+                                coords[1,'x'] <- coords[1,'x'] + extend_line
+                                coords[1,'xend'] <- coords[1,'xend'] + extend_line
+                                # horizontal line
+                                coords[2,'x'] <- coords[2,'x'] + extend_line
+                                coords[2,'xend'] <- coords[2,'xend'] - extend_line
+                                # right vertical segment
+                                coords[3,'x'] <- coords[3,'x'] - extend_line
+                                coords[3,'xend'] <- coords[3,'xend'] - extend_line
+                               }
                              }
                              grid::gList(
                                grid::textGrob(

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -159,14 +159,14 @@ StatSignif <- ggplot2::ggproto("StatSignif", ggplot2::Stat,
 #' @param margin_top numeric vector how much higher that the maximum value that bars start as fraction of total height
 #' @param step_increase numeric vector with the increase in fraction of total height for every additional comparison to
 #'   minimize overlap.
+#' @param extend_line Numeric that allows to shorten (negative values) or extend
+#'   (positive value) the horizontal line between groups for each comparison;
+#'   defaults to 0.
 #' @param tip_length numeric vector with the fraction of total height that the bar goes down to indicate the precise column
 #' @param parse If `TRUE`, the labels will be parsed into expressions and
 #'   displayed as described in `?plotmath`.
 #' @param manual boolean flag that indicates that the parameters are provided with a data.frame. This option is necessary if
 #'   one wants to plot different annotations per facet.
-#' @param extend_line Numeric that allows to shorten (negative values) or extend
-#'   (positive value) the horizontal line between groups for each comparison;
-#'   defaults to 0.
 #' @param na.rm If \code{FALSE} (the default), removes missing values with
 #'    a warning.  If \code{TRUE} silently removes missing values.
 #' @param ... other arguments passed on to \code{\link{layer}}. These are
@@ -236,28 +236,19 @@ GeomSignif <- ggplot2::ggproto("GeomSignif", ggplot2::Geom,
                                lab <- parse_safe(as.character(lab))
                              }
                              coords <- coord$transform(data, panel_params)
-                             if ( extend_line != 0 & nrow(coords) == 3 ) {
-                               if ( coords[2,'x'] < coords[2,'xend'] ) {
-                                # left vertical segment
-                                coords[1,'x'] <- coords[1,'x'] - extend_line
-                                coords[1,'xend'] <- coords[1,'xend'] - extend_line
-                                # horizontal line
-                                coords[2,'x'] <- coords[2,'x'] - extend_line
-                                coords[2,'xend'] <- coords[2,'xend'] + extend_line
-                                # right vertical segment
-                                coords[3,'x'] <- coords[3,'x'] + extend_line
-                                coords[3,'xend'] <- coords[3,'xend'] + extend_line
-                               } else if ( coords[2,'x'] > coords[2,'xend'] ) {
-                                # left vertical segment
-                                coords[1,'x'] <- coords[1,'x'] + extend_line
-                                coords[1,'xend'] <- coords[1,'xend'] + extend_line
-                                # horizontal line
-                                coords[2,'x'] <- coords[2,'x'] + extend_line
-                                coords[2,'xend'] <- coords[2,'xend'] - extend_line
-                                # right vertical segment
-                                coords[3,'x'] <- coords[3,'x'] - extend_line
-                                coords[3,'xend'] <- coords[3,'xend'] - extend_line
+                             if ( extend_line != 0 && nrow(coords) == 3 ) {
+                               if ( coords[2,'x'] > coords[2,'xend'] ) {
+                                extend_line <- - extend_line
                                }
+                               # left vertical segment
+                               coords[1,'x'] <- coords[1,'x'] - extend_line
+                               coords[1,'xend'] <- coords[1,'xend'] - extend_line
+                               # horizontal line
+                               coords[2,'x'] <- coords[2,'x'] - extend_line
+                               coords[2,'xend'] <- coords[2,'xend'] + extend_line
+                               # right vertical segment
+                               coords[3,'x'] <- coords[3,'x'] + extend_line
+                               coords[3,'xend'] <- coords[3,'xend'] + extend_line
                              }
                              grid::gList(
                                grid::textGrob(
@@ -295,11 +286,10 @@ geom_signif <- function(mapping = NULL, data = NULL, stat = "signif",
                         position = "identity", na.rm = FALSE, show.legend = NA,
                         inherit.aes = TRUE, comparisons=NULL, test="wilcox.test", test.args=NULL,
                         annotations=NULL, map_signif_level=FALSE,y_position=NULL,xmin=NULL, xmax=NULL,
-                        margin_top=0.05, step_increase=0, tip_length=0.03,
+                        margin_top=0.05, step_increase=0, extend_line = 0, tip_length=0.03,
                         size=0.5, textsize = 3.88, family="", vjust = 0,
                         parse = FALSE,
                         manual=FALSE,
-                        extend_line = 0,
                         ...) {
   params <- list(na.rm = na.rm, ...)
   if (identical(stat, "signif")) {
@@ -329,9 +319,9 @@ geom_signif <- function(mapping = NULL, data = NULL, stat = "signif",
                    annotations=annotations, map_signif_level=map_signif_level,
                    y_position=y_position,xmin=xmin, xmax=xmax,
                    margin_top=margin_top, step_increase=step_increase,
-                   tip_length=tip_length, size=size, textsize=textsize,
-                   family=family, vjust=vjust, parse=parse, manual=manual,
-                   extend_line = extend_line))
+                   extend_line = extend_line, tip_length=tip_length, size=size,
+                   textsize=textsize, family=family, vjust=vjust, parse=parse,
+                   manual=manual))
   }
   ggplot2::layer(
     stat = stat, geom = GeomSignif, mapping = mapping,  data = data,

--- a/R/significance_annotation.R
+++ b/R/significance_annotation.R
@@ -236,7 +236,6 @@ GeomSignif <- ggplot2::ggproto("GeomSignif", ggplot2::Geom,
                                lab <- parse_safe(as.character(lab))
                              }
                              coords <- coord$transform(data, panel_params)
-                             message(str(coords))
                              if ( extend_line != 0 & nrow(coords) == 3 ) {
                                if ( coords[2,'x'] < coords[2,'xend'] ) {
                                 # left vertical segment


### PR DESCRIPTION
Hi Constantin,

I implemented a new `extend_line` parameter that allows the user to horizontally shorten or extend the bracket line that is drawn between the groups for each comparison. Negative values shorten it, positive values extend it. I did this because when slightly shortening the lines, one can draw several comparisons on the same height (y position) without them overlapping, which saves some space and can look like this:

```r
ggplot(iris, aes(Species, Petal.Length)) +
geom_boxplot() +
geom_signif(
  comparisons = list(
    c('setosa','versicolor'),
    c('versicolor','virginica')
  ),
  extend_line = -0.01
) +
theme_bw()
```

![image](https://user-images.githubusercontent.com/18103560/84640052-774f5900-aef9-11ea-9f49-f4555938dbc3.png)

I think it's quite useful and hope you think so too.

There are 4 commits because the first implementation I made failed when the order of groups was such that the bracket line is drawn backward, e.g. from group 3 to group 2. Then I added some safety checks and removed a log message that I had forgotten.

Cheers,
Roman